### PR TITLE
fixed problem with SetPropery and timestamps

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -833,7 +833,7 @@ class LoggingBuildStep(BuildStep):
     renderables = [ 'logfiles', 'lazylogfiles' ]
 
     def __init__(self, logfiles={}, lazylogfiles=False, log_eval_func=None,
-                 *args, **kwargs):
+                 timestamp_stdio=False, *args, **kwargs):
         BuildStep.__init__(self, *args, **kwargs)
 
         if logfiles and not isinstance(logfiles, dict):
@@ -849,6 +849,7 @@ class LoggingBuildStep(BuildStep):
             config.error(
                 "the 'log_eval_func' paramater must be a callable")
         self.log_eval_func = log_eval_func
+        self.timestamp_stdio = timestamp_stdio
         self.addLogObserver('stdio', OutputProgressObserver("output"))
 
     def addLogFile(self, logname, filename):
@@ -871,6 +872,9 @@ class LoggingBuildStep(BuildStep):
 
         # stdio is the first log
         self.stdio_log = stdio_log = self.addLog("stdio")
+        # enable timestamps if requested
+        self.stdio_log.setTimestampsMode(self.timestamp_stdio)
+
         cmd.useLog(stdio_log, True)
         for em in errorMessages:
             stdio_log.addHeader(em)

--- a/master/buildbot/status/logfile.py
+++ b/master/buildbot/status/logfile.py
@@ -218,6 +218,8 @@ class LogFile:
         self.master = parent.build.builder.master
         self.name = name
         self.filename = logfilename
+        self.prepend_timestamps = False
+
         fn = self.getFilename()
         if os.path.exists(fn):
             # the buildmaster was probably stopped abruptly, before the
@@ -233,6 +235,16 @@ class LogFile:
         self.watchers = []
         self.finishedWatchers = []
         self.tailBuffer = []
+
+    def setTimestampsMode(self, prepend_timestamps):
+        """
+        Allows to enable/disable prepending of timestamps for each new line
+        added to this log.
+
+        @param prepend_timestamps: if True, timestamps will be prepended,
+                                   if False, no timetamps will be prepended
+        """
+        self.prepend_timestamps = prepend_timestamps
 
     def getFilename(self):
         """
@@ -459,7 +471,7 @@ class LogFile:
         if isinstance(text, unicode):
             text = text.encode('utf-8')
 
-        if (self.filename.endswith("stdio")):
+        if self.prepend_timestamps:
             lines = text.strip().split('\n')
             timetext = ""
             for l in lines:

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -86,6 +86,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
                  description=None, descriptionDone=None, descriptionSuffix=None,
                  command=None,
                  usePTY="slave-config",
+                 timestamp_stdio=True,
                  **kwargs):
         # most of our arguments get passed through to the RemoteShellCommand
         # that we create, but first strip out the ones that we pass to
@@ -115,7 +116,9 @@ class ShellCommand(buildstep.LoggingBuildStep):
             if k in self.__class__.parms:
                 buildstep_kwargs[k] = kwargs[k]
                 del kwargs[k]
-        buildstep.LoggingBuildStep.__init__(self, **buildstep_kwargs)
+        buildstep.LoggingBuildStep.__init__(self,
+                                            timestamp_stdio=timestamp_stdio,
+                                            **buildstep_kwargs)
 
         # everything left over goes to the RemoteShellCommand
         kwargs['workdir'] = workdir # including a copy of 'workdir'
@@ -316,7 +319,7 @@ class SetProperty(ShellCommand):
             config.error(
                 "Exactly one of property and extract_fn must be set")
 
-        ShellCommand.__init__(self, **kwargs)
+        ShellCommand.__init__(self, timestamp_stdio=False, **kwargs)
 
         self.property_changes = {}
 

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -135,6 +135,9 @@ class FakeLogFile(object):
                         for (ch, data) in self.chunks
                         if not channels or ch in channels ]
 
+    def setTimestampsMode(self, prepend_timestamps):
+        pass
+
     def finish(self):
         pass
 


### PR DESCRIPTION
Prepending timestamps to stdio log breaks SetProperty, the timestamp will be included into the property value.

Make it possible to toggle the prepending of time stamps to logs. For SetProperty steps, disable timestamps.