### PR TITLE
Feature/buildrequest slave info

### DIFF
--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -56,7 +56,7 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
             return [ self._bdictFromRow(row) for row in res.fetchall() ]
         return self.db.pool.do(thd)
 
-    def addBuild(self, brid, number, slavename, _reactor=reactor):
+    def addBuild(self, brid, number, slavename=None, _reactor=reactor):
         def thd(conn):
             start_time = _reactor.seconds()
             r = conn.execute(self.db.model.builds.insert(),

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -105,7 +105,7 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
 
         return self.db.pool.do(thd)
 
-    def getLastsBuildsNumbersBySlave(self, slavename, num_builds=1):
+    def getLastsBuildsNumbersBySlave(self, slavename, num_builds=15):
         def thd(conn):
             buildrequests_tbl = self.db.model.buildrequests
             builds_tbl = self.db.model.builds
@@ -137,8 +137,6 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
             return lastBuilds
 
         return self.db.pool.do(thd)
-
-
 
     def getLastBuildsNumbers(self, buildername=None, sourcestamps=None, num_builds=1):
         def thd(conn):

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -127,7 +127,7 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
             rows = res.fetchall()
             if rows:
                 for row in rows:
-                    if row.buildername not in lastBuilds.keys():
+                    if row.buildername not in lastBuilds:
                         lastBuilds[row.buildername] = [row.number]
                     else:
                         lastBuilds[row.buildername].append(row.number)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -365,9 +365,15 @@ class Builder(config.ReconfigurableServiceMixin,
         # record the build in the db - one row per buildrequest
         try:
             bids = []
-            for req in build.requests:
-                bid = yield self.master.db.builds.addBuild(req.id, bs.number, slavebuilder.slave.slavename)
+
+            if len(build.requests) > 0:
+                main_br = build.requests[0]
+                bid = yield self.master.db.builds.addBuild(main_br.id, bs.number, slavebuilder.slave.slavename)
                 bids.append(bid)
+                # add build information to merged br
+                for req in build.requests[1:]:
+                    bid = yield self.master.db.builds.addBuild(req.id, bs.number)
+                    bids.append(bid)
         except:
             log.err(failure.Failure(), 'while adding rows to build table:')
             run_cleanups()

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -381,7 +381,7 @@ class Builder(config.ReconfigurableServiceMixin,
             return
 
         # let status know
-        self.master.status.build_started(req.id, self.name, bs)
+        self.master.status.build_started(main_br.id, self.name, bs)
 
         # start the build. This will first set up the steps, then tell the
         # BuildStatus that it has started, which will announce it to the world

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -463,8 +463,6 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
             shutil.rmtree(filename, ignore_errors=True)
         tmpfilename = filename + ".tmp"
 
-        if os.path.exists(tmpfilename):
-            return
         try:
             with open(tmpfilename, "wb") as f:
                 dump(self, f, -1)
@@ -476,8 +474,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
                 if os.path.exists(filename):
                     os.unlink(filename)
 
-            if os.path.exists(tmpfilename):
-                os.rename(tmpfilename, filename)
+            os.rename(tmpfilename, filename)
         except:
             log.msg("unable to save build %s-#%d" % (self.builder.name,
                                                      self.number))

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -462,6 +462,9 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
             # leftover from 0.5.0, which stored builds in directories
             shutil.rmtree(filename, ignore_errors=True)
         tmpfilename = filename + ".tmp"
+
+        if os.path.exists(tmpfilename):
+            return
         try:
             with open(tmpfilename, "wb") as f:
                 dump(self, f, -1)
@@ -472,7 +475,9 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
                 # general (non-windows) case
                 if os.path.exists(filename):
                     os.unlink(filename)
-            os.rename(tmpfilename, filename)
+
+            if os.path.exists(tmpfilename):
+                os.rename(tmpfilename, filename)
         except:
             log.msg("unable to save build %s-#%d" % (self.builder.name,
                                                      self.number))

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -186,6 +186,9 @@ class BuilderStatus(styles.Versioned):
 
         filename = os.path.join(self.basedir, "builder")
         tmpfilename = filename + ".tmp"
+
+        if os.path.exists(tmpfilename):
+            return
         try:
             with open(tmpfilename, "wb") as f:
                 dump(self, f, -1)
@@ -193,7 +196,9 @@ class BuilderStatus(styles.Versioned):
                 # windows cannot rename a file on top of an existing one
                 if os.path.exists(filename):
                     os.unlink(filename)
-            os.rename(tmpfilename, filename)
+
+            if os.path.exists(tmpfilename):
+                os.rename(tmpfilename, filename)
         except:
             log.msg("unable to save builder %s" % self.name)
             log.err()

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -488,7 +488,7 @@ class BuilderStatus(styles.Versioned):
         return build
 
     def loadBuildFromThread(self, buildnumber):
-        if buildnumber not in self.loadingBuilds.keys():
+        if buildnumber not in self.loadingBuilds:
             d = threads.deferToThread(self.getBuild, buildnumber)
             d.addCallback(self.buildLoaded, buildnumber=buildnumber)
             self.loadingBuilds[buildnumber] = {'defer': d, 'access': 1, 'build': None}
@@ -499,6 +499,10 @@ class BuilderStatus(styles.Versioned):
 
     @defer.inlineCallbacks
     def deferToThread(self, buildnumber):
+        if buildnumber in self.buildCache.cache:
+            defer.returnValue(self.getBuildByNumber(number=buildnumber))
+            return
+
         self.loadBuildFromThread(buildnumber=buildnumber)
         yield self.loadingBuilds[buildnumber]['defer']
         build = self.getLoadedBuildFromThread(buildnumber)

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -328,7 +328,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
         all_builds = []
         for bn in builder_names:
             b = self.getBuilder(bn)
-            finished_builds = yield b.generateFinishedBuildsAsync(num_builds=num_builds, max_search=200,
+            finished_builds = yield b.generateFinishedBuildsAsync(num_builds=num_builds,
                                                                   results=results, slavename=slavename)
             all_builds.extend(finished_builds)
 

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -552,15 +552,7 @@ class PastBuildsJsonResource(JsonResource):
         if self.slave_status is not None:
             slavename = self.slave_status.getName()
 
-            my_builders = []
-            for bname in self.status.getBuilderNames():
-                b = self.status.getBuilder(bname)
-                for bs in b.getSlaves():
-                    if bs.getName() == slavename:
-                        my_builders.append(b)
-
-            builds = yield self.status.generateFinishedBuildsAsync(builders=[b.getName() for b in my_builders],
-                                                                   num_builds=self.number, results=results,
+            builds = yield self.status.generateFinishedBuildsAsync(num_builds=self.number, results=results,
                                                                    slavename=slavename)
 
             defer.returnValue([rb.asDict(request=request) for rb in builds])

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1118,7 +1118,7 @@ class FakeBuildsComponent(FakeDBComponent):
             start_time=epoch2datetime(row.start_time),
             finish_time=epoch2datetime(row.finish_time)))
 
-    def getLastBuildsNumbers(self, buildername=None, sourcestamps=None, num_builds=1):
+    def getLastBuildsNumbers(self, buildername=None, slavename=None, sourcestamps=None, num_builds=1):
         return defer.succeed([])
     
     def getBuildsForRequest(self, brid):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1147,7 +1147,7 @@ class FakeBuildsComponent(FakeDBComponent):
 
         return defer.succeed(ret)
 
-    def addBuild(self, brid, number, slavename,_reactor=reactor):
+    def addBuild(self, brid, number, slavename=None,_reactor=reactor):
         bid = self._newId()
         self.builds[bid] = Build(id=bid, number=number, brid=brid, slavename=slavename,
                 start_time=_reactor.seconds, finish_time=None)

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -28,7 +28,8 @@ class TestBuilderStatus(unittest.TestCase):
         self.master.getProject = lambda x: self.project
         self.getProjects = lambda: {'Katana': self.project}
 
-        self.master.db.builds.getLastBuildsNumbers = lambda buildername, sourcestamps, num_builds: defer.succeed([38])
+        self.master.db.builds.getLastBuildsNumbers = lambda buildername, slavename, sourcestamps, num_builds: \
+            defer.succeed([38])
 
         self.builder_status = builder.BuilderStatus(buildername="builder-01", category=None,
                                     master=self.master)
@@ -63,7 +64,7 @@ class TestBuilderStatus(unittest.TestCase):
 
         builds = yield self.builder_status.generateFinishedBuildsAsync(branches=[],
                                                                        codebases=codebases,
-                                                                       num_builds=1, max_search=200,
+                                                                       num_builds=1,
                                                                        useCache=True)
 
         self.assertTrue(len(builds) > 0)
@@ -80,7 +81,6 @@ class TestBuilderStatus(unittest.TestCase):
         builds = yield self.builder_status.generateFinishedBuildsAsync(branches=[],
                                                                        codebases=codebases,
                                                                        num_builds=1,
-                                                                       max_search=200,
                                                                        useCache=True)
 
         self.assertTrue('katana-buildbot=katana;' in self.builder_status.latestBuildCache.keys())
@@ -110,7 +110,8 @@ class TestBuilderStatus(unittest.TestCase):
 
         codebases = {'codebase1': 'branch1', 'codebase2': 'branch2'}
 
-        self.master.db.builds.getLastBuildsNumbers = lambda buildername, sourcestamps, num_builds: defer.succeed([])
+        self.master.db.builds.getLastBuildsNumbers = lambda buildername, slavename, sourcestamps, num_builds: \
+            defer.succeed([])
 
         self.assertEqual(self.builder_status.latestBuildCache, {})
 
@@ -137,7 +138,8 @@ class TestBuilderStatus(unittest.TestCase):
         self.multipleCodebasesProject()
         codebases = {'codebase1': 'branch1', 'codebase2': 'branch2'}
 
-        self.master.db.builds.getLastBuildsNumbers = lambda buildername, sourcestamps, num_builds: defer.succeed([])
+        self.master.db.builds.getLastBuildsNumbers = lambda buildername, slavename, sourcestamps, num_builds: \
+            defer.succeed([])
 
         self.assertEqual(self.builder_status.latestBuildCache, {})
 

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -28,7 +28,7 @@ class TestBuilderStatus(unittest.TestCase):
         self.master.getProject = lambda x: self.project
         self.getProjects = lambda: {'Katana': self.project}
 
-        self.master.db.builds.getLastBuildsNumbers = lambda buildername, slavename, sourcestamps, num_builds: \
+        self.master.db.builds.getLastBuildsNumbers = lambda buildername, sourcestamps, num_builds: \
             defer.succeed([38])
 
         self.builder_status = builder.BuilderStatus(buildername="builder-01", category=None,
@@ -110,7 +110,7 @@ class TestBuilderStatus(unittest.TestCase):
 
         codebases = {'codebase1': 'branch1', 'codebase2': 'branch2'}
 
-        self.master.db.builds.getLastBuildsNumbers = lambda buildername, slavename, sourcestamps, num_builds: \
+        self.master.db.builds.getLastBuildsNumbers = lambda buildername, sourcestamps, num_builds: \
             defer.succeed([])
 
         self.assertEqual(self.builder_status.latestBuildCache, {})
@@ -138,7 +138,7 @@ class TestBuilderStatus(unittest.TestCase):
         self.multipleCodebasesProject()
         codebases = {'codebase1': 'branch1', 'codebase2': 'branch2'}
 
-        self.master.db.builds.getLastBuildsNumbers = lambda buildername, slavename, sourcestamps, num_builds: \
+        self.master.db.builds.getLastBuildsNumbers = lambda buildername, sourcestamps, num_builds: \
             defer.succeed([])
 
         self.assertEqual(self.builder_status.latestBuildCache, {})

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -38,6 +38,7 @@ class TestBuilderStatus(unittest.TestCase):
         self.builder_status.master = self.master
 
         self.builder_status.buildCache = Mock()
+        self.builder_status.buildCache.cache = {}
 
         def getCachedBuild(number):
             build_status = BuildStatus(self.builder_status, self.master, number)


### PR DESCRIPTION
1.- Add support for getLastsBuildsNumbersBySlave this improves the performance of buildslaves pages
2.- Fix query to exclude merged build request, affects last builds page
3.- Handle thread safe when loading builds