### PR TITLE
Feature/json build info

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -356,10 +356,17 @@ class Build(properties.PropertiesMixin):
         self.build_status.setBlamelist(self.blamelist())
         self.build_status.setProgress(self.progress)
 
+        if len(self.requests) > 0:
+            self.build_status.setSubmitted(self.requests[0].submittedAt)
+            self.setProperty("submittedTime", self.requests[0].submittedAt, "buildrequest")
+            self.build_status.setBuildChainID(self.requests[0].buildChainID)
+            self.setProperty("buildChainID", self.requests[0].buildChainID, "buildrequest")
+
         # gather owners from build requests
         owners = [r.properties['owner'] for r in self.requests
                   if r.properties.has_key('owner')]
         if owners: self.setProperty('owners', owners, self.reason)
+        self.build_status.setOwners(owners)
 
         self.results = [] # list of FAILURE, SUCCESS, WARNINGS, SKIPPED
         self.result = SUCCESS # overall result, may downgrade after each step

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -102,6 +102,13 @@ class BuildRequest(object):
         buildrequest.submittedAt = dt and calendar.timegm(dt.utctimetuple())
         buildrequest.master = master
 
+        def getBuilChainID():
+            if 'startbrid' in brdict and brdict['startbrid'] is not None:
+                return brdict['startbrid']
+            return brid
+
+        buildrequest.buildChainID = getBuilChainID()
+
         # fetch the buildset to get the reason
         buildset = yield master.db.buildsets.getBuildset(brdict['buildsetid'])
         assert buildset # schema should guarantee this

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -44,6 +44,9 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
     progress = None
     started = None
     finished = None
+    submitted = None
+    owners = None
+    buildChainID = None
     currentStep = None
     text = []
     results = None
@@ -295,6 +298,15 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         self.changes = []
         for source in self.sources:
             self.changes.extend(source.changes)
+
+    def setSubmitted(self, submitted):
+        self.submitted = submitted
+
+    def setBuildChainID(self, buildChainID):
+        self.buildChainID = buildChainID
+
+    def setOwners(self, owners):
+        self.owners = owners
 
     def setReason(self, reason):
         self.reason = reason
@@ -553,6 +565,9 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         result['builderFriendlyName'] = self.builder.getFriendlyName()
         result['number'] = self.getNumber()
         result['reason'] = self.getReason()
+        result['submittedTime'] = self.submitted
+        result['owners'] = self.owners
+        result['buildChainID'] = self.buildChainID
         result['blame'] = self.getResponsibleUsers()
         result['url'] = status.getURLForThing(self)
         result['url']['path'] += args

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -88,7 +88,7 @@ class Source(LoggingBuildStep):
         default value will then match all changes.
         """
 
-        LoggingBuildStep.__init__(self, **kwargs)
+        LoggingBuildStep.__init__(self, timestamp_stdio=True, **kwargs)
 
         # This will get added to args later, after properties are rendered
         self.workdir = workdir

--- a/master/buildbot/test/regressions/test_shell_command_properties.py
+++ b/master/buildbot/test/regressions/test_shell_command_properties.py
@@ -47,6 +47,15 @@ class FakeBuildStatus:
     def setReason(self, reason):
         self.reason = reason
 
+    def setSubmitted(self, submitted):
+        self.submitted = submitted
+
+    def setBuildChainID(self, buildChainID):
+        self.buildChainID = buildChainID
+
+    def setOwners(self, owners):
+        self.owners = owners
+
     def setBlamelist(self, bl):
         self.bl = bl
 
@@ -69,6 +78,8 @@ class FakeBuildRequest:
         self.sources = sources
         self.buildername = buildername
         self.changes = []
+        self.submittedAt = None
+        self.buildChainID = None
         self.properties = Properties()
 
     def mergeSourceStampsWith(self, others):
@@ -76,6 +87,9 @@ class FakeBuildRequest:
 
     def mergeReasons(self, others):
         return self.reason
+
+def setProperty(propname, value, source='Unknown', runtime=None):
+    pass
 
 
 class TestShellCommandProperties(unittest.TestCase):
@@ -92,6 +106,7 @@ class TestShellCommandProperties(unittest.TestCase):
         b.build_status = FakeBuildStatus()
         b.slavebuilder = FakeSlaveBuilder()
         b.builder = FakeBuilder()
+        b.setProperty = setProperty
 
         # This shouldn't raise an exception
         b.setupBuild(None)
@@ -110,6 +125,7 @@ class TestSetProperty(unittest.TestCase):
         b.build_status = FakeBuildStatus()
         b.slavebuilder = FakeSlaveBuilder()
         b.builder = FakeBuilder()
+        b.setProperty = setProperty
 
         # This shouldn't raise an exception
         b.setupBuild(None)

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -51,6 +51,8 @@ class FakeRequest:
         self.sources = []
         self.reason = "Because"
         self.properties = Properties()
+        self.submittedAt = None
+        self.buildChainID = None
 
     def mergeSourceStampsWith(self, others):
         return self.sources

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -164,6 +164,7 @@ class TestBuildJsonResource(unittest.TestCase):
                                                         'url': u'https://github.com/test/repo/commit/abcdef123456789'}],
                           'results': 0, 'number': 1, 'currentStep': None,
                           'times': (None, 1422441501.21, 1422441501.21),
+                          'buildChainID': None, 'owners': None, 'submittedTime': None,
                           'blame': [],
                           'builder_url': 'http://localhost:8080/projects/Katana/builders/builder-01' +
                                          '?katana-buildbot_branch=katana&_branch=b',
@@ -263,7 +264,8 @@ class TestPastBuildsJsonResource(unittest.TestCase):
                     'number': num, 'properties': [], 'reason': 'A build was forced by user@localhost',
                     'results': 0, 'results_text': 'success', 'slave': 'build-slave-01',
                     'slave_friendly_name': 'build-slave-01', 'slave_url': None,
-                    'sourceStamps': [], 'steps': [],
+                    'sourceStamps': [], 'steps': [], 'buildChainID': None, 'owners': None,
+                     'submittedTime': None,
                     'text': [], 'times': (None, 1422441501.21, 1422441501.21),
                     'url': {
                         'path':
@@ -384,7 +386,8 @@ class TestSingleProjectJsonResource(unittest.TestCase):
                      'text': [],
                      'sourceStamps': [],
                      'results': 0,
-                     'number': 1, 'artifacts': None, 'blame': [],
+                     'number': 1, 'artifacts': None, 'blame': [], 'buildChainID': None, 'owners': None,
+                     'submittedTime': None,
                      'builder_url': 'http://localhost:8080/projects/Katana/builders/builder-01' +
                                     '?katana-buildbot_branch=katana',
                      'reason': 'A build was forced by user@localhost',

--- a/master/buildbot/test/unit/test_step_locks.py
+++ b/master/buildbot/test/unit/test_step_locks.py
@@ -13,6 +13,8 @@ class FakeRequest:
         self.sources = []
         self.reason = "Because"
         self.properties = Properties()
+        self.submittedAt = None
+        self.buildChainID = None
 
     def mergeSourceStampsWith(self, others):
         return self.sources


### PR DESCRIPTION
Include more information into json about when a build was submitted and send katana's chain id
Turn on timestamps on hg / git steps